### PR TITLE
Fixes pushing symbols NuGet package twice

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -427,6 +427,7 @@ Task("NuGetFeed")
         }
         else
         {
+            // pushes symbols package too (see https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg)
             NuGetPush(
                 package,
                 new NuGetPushSettings {
@@ -435,17 +436,6 @@ Task("NuGetFeed")
                 }
             );
         }
-    }
-    var symbols = GetFiles($"{buildArtifacts.Path}/*.snupkg");
-    foreach(var symbol in symbols)
-    {
-        NuGetPush(
-            symbol,
-            new NuGetPushSettings {
-                Source = nuGetSource,
-                ApiKey = nugetReleaseToken
-            }
-        );
     }
 });
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds (VisualStudio & cake script: build.ps1)
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or paste a link to an open issue -->
fixes #60 

### What is the new behavior?
<!-- Describe the new behavior -->

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information
